### PR TITLE
Fix require argument

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -5,7 +5,7 @@ Deployer has a set of predefined tasks called _recipes_.
 Recipes can be included to your `deploy.php` file like this:
 
 ~~~ php
-require 'recipe/common.php';
+require './recipe/common.php';
 ~~~
 
 ### Common Recipe


### PR DESCRIPTION
`deployer.phar` has `recipe/common.php` in it, so `require 'recipe/common.php';` does not load `common.php` in your file system.

If you create `recipe/common.php` and change it, it does not effect.
