### PR TITLE
Updated server documentation to clear up usage of identity_file

### DIFF
--- a/servers.md
+++ b/servers.md
@@ -114,7 +114,10 @@ prod:
 prod.a:
   host: a.domain.com
   user: www
-  identity_file: ~
+  identity_file:
+    public_key:  /path/to/public.key
+    private_key: /path/to/private.key
+    password:    optional-password-for-private-key-or-null
   stage: production
   deploy_path: /home/www/  
   


### PR DESCRIPTION
Updated server documentation to clear up usage of identity_file configuration in YAML

Changed `prod.a` server configuration to contain `public_key`, `private_key` and `password` subtree.