### PR TITLE
Example for keyword local: in .yml definition

### DIFF
--- a/servers.md
+++ b/servers.md
@@ -167,6 +167,14 @@ localServer(...)
     ->stage('local');
 ~~~
 
+In external .yml definition the keyword `local: `can be used.
+
+~~~ yml
+development:
+    local: true
+    # ....
+~~~
+
 For instance, you can use it for update your local project.
 
 ## Stages


### PR DESCRIPTION
Show alternative way in external yml definition for defining a server to be local