### PR TITLE
Fix "cleanup" task name

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -61,7 +61,7 @@ task('deploy', [
     'deploy:update_code',
     'deploy:vendors',
     'deploy:symlink',
-    'deploy:cleanup'
+    'cleanup'
 ]);
 ```
 


### PR DESCRIPTION
This task is named "cleanup", not "deploy:cleanup"

See: https://github.com/deployphp/deployer/blob/5586de7e6388f9ef2b5d1d55b5f19412c672e314/recipe/common.php#L376