### PR TITLE
correct deploy:writable recipe name

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -49,7 +49,7 @@ set('shared_dirs', ['app/logs']);
 set('shared_files', ['app/config/parameters.yml']);
 ```
 
-#### deploy:writable_dirs
+#### deploy:writable
 
 Creates writable directories.
 


### PR DESCRIPTION
Changed incorrect recipe name `deploy:writable_dirs` to correct recipe name `deploy:writable` as seen here [common.php:234](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L234)