### PR TITLE
Fix "Using input options" section

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -95,15 +95,17 @@ Also you can specify a group on servers to run as arguments: `->onlyOn('server1'
 
 ### Using input options
 
-You can define additional input options and arguments:
+You can define additional input options and arguments, before defining tasks:
 
 ``` php
-argument('stage', InputArgument::OPTIONAL, 'Run tasks only on this server or group of servers.');
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
+argument('stage', InputArgument::OPTIONAL, 'Run tasks only on this server or group of servers.');
 option('tag', null, InputOption::VALUE_OPTIONAL, 'Tag to deploy.');
 ```
 
-To get the input inside a task this can be used
+To get the input inside a task this can be used:
 
 ``` php
 task('foo:bar', function() {


### PR DESCRIPTION
Without specifying the full namespace it throws a Class Not Found error, so the docs should include the full namespace on the example. Also, it specifies that the arguments and options definition should be before any task definition.