### PR TITLE
Updates doc to include git branch example

### DIFF
--- a/environment.md
+++ b/environment.md
@@ -68,3 +68,9 @@ env('current', function () {
     return run("readlink {{deploy_path}}/current")->toString();
 });
 ```
+
+You can also change the git branch beeing deployed.
+``` php
+env('branch', 'development');
+```
+


### PR DESCRIPTION
Solving a very annoying problem I had as there was no obvious way of setting the branch name. Figured it out only after the reading the code. This should probably be in the basic example.