### PR TITLE
Corrected spelling of "second" on servers page doc

### DIFF
--- a/servers.md
+++ b/servers.md
@@ -58,7 +58,7 @@ server(...)
 
 ### 2-factor authentication with an identity file and password or google-authenticator:
 
-If your server is secured with 2-factor, you can connect via your private key + the sccond factor (password or google-authenticator).  Note this the current version only supports *PhpSecLib*:
+If your server is secured with 2-factor, you can connect via your private key + the second factor (password or google-authenticator).  Note this the current version only supports *PhpSecLib*:
 
 ~~~ php
 server(...)


### PR DESCRIPTION
Super small PR with a typo fix that I came across while reading through the docs. Figured I'd submit the change before I forget. :)