### PR TITLE
Update api.md for Typo

### DIFF
--- a/api.md
+++ b/api.md
@@ -20,7 +20,7 @@ Load list of hosts from file.
 
 ### desc
 
-* `desk(string $description)`
+* `desc(string $description)`
 
 Set task description.
 

--- a/configuration.md
+++ b/configuration.md
@@ -179,11 +179,11 @@ List of paths which need to be deleted in release after updating code.
 
 ### clear_use_sudo
 
-Use or ro not `sudo` with clear_paths. Default to `false`.
+Use or not `sudo` with clear_paths. Default to `false`.
 
 ### cleanup_use_sudo
 
-Use or ro not `sudo` with `cleanup` task. Default to `false`.
+Use or not `sudo` with `cleanup` task. Default to `false`.
 
 ### use_relative_symlink
 


### PR DESCRIPTION
Some typos and/or Engrish that I have found when going through the docs.

One recommendation I would make would be to add types to the variables.  Using `git_tty` as an example, I would never know that it is to be a boolean value.