### PR TITLE
fix method name of host

### DIFF
--- a/hosts.md
+++ b/hosts.md
@@ -146,9 +146,9 @@ domain.com:
   identityFile: ~/.ssh/id_rsa
   forwardAgent: true
   multiplexing: true
-  options:
-    - UserKnownHostsFile=/dev/null
-    - StrictHostKeyChecking=no
+  sshOptions:
+    UserKnownHostsFile: /dev/null
+    StrictHostKeyChecking: no
   stage: production
   roles:
     - app


### PR DESCRIPTION
In last version doesn't use ```options```
https://github.com/deployphp/deployer/blob/master/src/Host/FileLoader.php#L54