### PR TITLE
Modify info about possible installation methods with new Deployer Distribution

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -8,19 +8,6 @@ Deployer can be installed in three ways:
 
 The best option for most cases is to choose  **composer package with phar only**. 
 
-Two other methods have following disadvantages:
-
-* If you will install Deployer globally as **phar archive** then it will fit your needs well until the amount of 
-  projects will increase. Its quite possible that if you have big amount of projects then you will be not able to 
-  upgrade all deploy.php configs at each project at one time to newer version of deployer. So for some time you will 
-  need to have two or more versions of deployer installed globally under different names. For example "dep" for 
-  deployer5, "dep4" for deployer4 and then run commands like "dep4 deploy production" or "dep deploy production" - 
-  depends on which project you are. Additionally if new developer is coming into project he needs to install all 
-  versions of Deployer binaries on his local computer.
-
-* If you will install Deployer as **composer package with sources** then you risk that deployer dependencies 
-  will be in conflict with your project dependencies. Its quite often the conflict with monolog/monolog package or
-  symfony/console package.
 
 ### Composer package with phar only
 

--- a/installation.md
+++ b/installation.md
@@ -1,50 +1,11 @@
 # Installation
 
-Deployer can be installed in three ways: 
-1) using **composer package with phar only** - later called also "Deployer Distribution" version (no dependencies)
-2) using **composer package with sources** - later called also "Deployer Source" version (dependencies but good for debug 
-   Deployer) 
-3) using direct download of **phar archive**
+There are three ways to install deployer: 
+1) download phar archive
+2) source composer installation
+3) distribution composer installation
 
-The best option for most cases is to choose  **composer package with phar only**. 
-
-
-### Composer package with phar only
-
-To install Deployer Distribution version with Composer, run the command:
-
-```sh
-composer require deployer/dist --dev
-```
-
-Then to use Deployer, run the following command:
-
-```sh
-php vendor/bin/dep
-```
-
-If you want to run deployer with `dep` only instead of `php vendor/bin/dep` then you need to add 
-`export PATH="$PATH:./vendor/bin"` to your ~/.bashrc or ~/.profile file. For security reason mind to add
-it on the very end of file so binaries read from project ./vendor/bin folder are the last taken into consideration.
-Remember that you need to open new shell after changes in ~/.bashrc or ~/.profile file so the new config is loaded.  
-
-
-### Composer package with sources
-
-To install Deployer Source version with Composer, run the command:
-
-```sh
-composer require deployer/deployer --dev
-```
-
-Then to use Deployer, run the following command:
-
-```sh
-php vendor/bin/dep
-```
-
-
-### Phar archive
+### Download phar archive
 
 To install Deployer as phar archive, run the following commands:
 
@@ -67,8 +28,47 @@ To upgrade to the next major release, if available, use the `--upgrade (-u)` opt
 dep self-update --upgrade
 ```
 
+### Source composer installation
 
-### Source
+To install Deployer source version with Composer, run the command:
+
+```sh
+composer require deployer/deployer --dev
+```
+
+You can also install it globally:
+
+``` sh
+composer global require deployer/deployer
+```
+
+More info: https://getcomposer.org/doc/03-cli.md#global
+
+Then to use Deployer, run the following command:
+
+```sh
+php vendor/bin/dep
+```
+
+> If you have installed Deployer using **both** methods, running `dep` command will prefer a composer-installed version. 
+
+> If you have dependency conflicts you can use "distribution composer installation"
+
+### Distribution composer installation
+
+To install Deployer distribution version with Composer, run the command:
+
+```sh
+composer require deployer/dist --dev
+```
+
+Then to use Deployer, run the following command:
+
+```sh
+php vendor/bin/dep
+```
+
+### Own builded phar
 
 If you want to build Deployer from the source code, clone the project from GitHub:
 
@@ -83,6 +83,7 @@ php bin/build
 ```
 
 This will build the `deployer.phar` phar archive.
+
 
 ### Autocomplete
 

--- a/installation.md
+++ b/installation.md
@@ -1,10 +1,65 @@
 # Installation
 
-Deployer can be installed in two ways: using phar archive and using composer.
+Deployer can be installed in three ways: 
+1) using **composer package with phar only** - later called also "Deployer Distribution" version (no dependencies)
+2) using **composer package with sources** - later called also "Deployer Source" version (dependencies but good for debug 
+   Deployer) 
+3) using direct download of **phar archive**
+
+The best option for most cases is to choose  **composer package with phar only**. 
+
+Two other methods have following disadvantages:
+
+* If you will install Deployer globally as **phar archive** then it will fit your needs well until the amount of 
+  projects will increase. Its quite possible that if you have big amount of projects then you will be not able to 
+  upgrade all deploy.php configs at each project at one time to newer version of deployer. So for some time you will 
+  need to have two or more versions of deployer installed globally under different names. For example "dep" for 
+  deployer5, "dep4" for deployer4 and then run commands like "dep4 deploy production" or "dep deploy production" - 
+  depends on which project you are. Additionally if new developer is coming into project he needs to install all 
+  versions of Deployer binaries on his local computer.
+
+* If you will install Deployer as **composer package with sources** then you risk that deployer dependencies 
+  will be in conflict with your project dependencies. Its quite often the conflict with monolog/monolog package or
+  symfony/console package.
+
+### Composer package with phar only
+
+To install Deployer Distribution version with Composer, run the command:
+
+```sh
+composer require deployer/dist --dev
+```
+
+Then to use Deployer, run the following command:
+
+```sh
+php vendor/bin/dep
+```
+
+If you want to run deployer with `dep` only instead of `php vendor/bin/dep` then you need to add 
+`export PATH="$PATH:./vendor/bin"` to your ~/.bashrc or ~/.profile file. For security reason mind to add
+it on the very end of file so binaries read from project ./vendor/bin folder are the last taken into consideration.
+Remember that you need to open new shell after changes in ~/.bashrc or ~/.profile file so the new config is loaded.  
+
+
+### Composer package with sources
+
+To install Deployer Source version with Composer, run the command:
+
+```sh
+composer require deployer/deployer --dev
+```
+
+Then to use Deployer, run the following command:
+
+```sh
+php vendor/bin/dep
+```
+
 
 ### Phar archive
 
-To install Deployer via phar archive, run the following commands:
+To install Deployer as phar archive, run the following commands:
 
 ```sh
 curl -LO https://deployer.org/deployer.phar
@@ -25,29 +80,6 @@ To upgrade to the next major release, if available, use the `--upgrade (-u)` opt
 dep self-update --upgrade
 ```
 
-### Composer
-
-To install Deployer with Composer, run the command:
-
-```sh
-composer require deployer/deployer --dev
-```
-
-You can also install it globally:
-
-``` sh
-composer global require deployer/deployer
-```
-
-More info: https://getcomposer.org/doc/03-cli.md#global
-
-Then to use Deployer, run the following command:
-
-```sh
-php vendor/bin/dep
-```
-
-> If you have installed Deployer using **both** methods, running `dep` command will prefer a composer-installed version. 
 
 ### Source
 


### PR DESCRIPTION
@antonmedv 

I removed info about composer global install as it probably is not so important now when there is better and preferable method of installation. 

IMHO - all global installs of Deployer have big drawback that in longer time we need several versions of Deployer installed globally because its quite impossible to upgrade deploy.php on all projects to every new version of deployer. So global install of phar or global install with composer will suffer problems in long term. The best solution is locally installed phar from Deployer Distribution.

But if you think the info about global composer install is crucial then let me know so I will bring it back.
