### PR TITLE
Fix doc for fail function

### DIFF
--- a/api.md
+++ b/api.md
@@ -46,7 +46,7 @@ Call after `$when` task, `$that` task.
 
 ### fail
 
-* `fail(string $when, string $that)`
+* `fail(string $what, string $that)`
 
 If task `$what` fails, run `$that` task.
 


### PR DESCRIPTION
So that `fail` method parameter and parameter in comment were the same