### PR TITLE
Add trailing slash in upload usage example

### DIFF
--- a/advanced/deploy-strategies.md
+++ b/advanced/deploy-strategies.md
@@ -49,7 +49,7 @@ After create an _upload_ task:
 
 ~~~php
 task('upload', function () {
-    upload(__DIR__, '{{release_path}}');
+    upload(__DIR__ . "/", '{{release_path}}');
 });
 ~~~
 


### PR DESCRIPTION
The variant with the trailing slash (copy *the contents of* `__DIR__`) is probably more often desired than the one without the trailing slash (copy the directory itself), and thus better to illustrate typical usage of `upload()`.