### PR TITLE
Making it more clear that this repo is depreciated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 >
+> # This repo has been depreciated and is no longer used
 > ### Documentation migrated into [deployer repository](https://github.com/deployphp/deployer/tree/master/docs)
 >
 


### PR DESCRIPTION
I was briefly confused when working on the documentation by this repo. I see now that all docs live in the main repo, so I added a clear "ignore this" message to this repo. :-) It's a very small change but, as always, may save someone else some time/energy in the future.